### PR TITLE
Changing product weight should have effect on real time shipping calculation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,12 +5,13 @@ gem 'spree', :github => 'godaddy/spree', :branch => '2-2-nemo-stable'
 gemspec
 
 group :development, :test do
-  gem 'rails', '4.0.9' #Temporary version lock to 4.0.9 to avoid bad rails version.
+  gem 'rails', '~> 4.0.9'
   gem 'factory_girl_rails', '~> 4.5.0'
   gem 'simplecov-rcov'
   gem 'yarjuf'
   gem 'require_all'
   gem 'awesome_print'
   gem 'rspec', '~> 2.99'
+  gem 'test-unit'
 end
 

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -263,12 +263,13 @@ module Spree
         end
 
         def cache_key(package)
+          multiplier = Spree::ActiveShipping::Config[:unit_multiplier]
           stock_location = package.stock_location.nil? ? "" : "#{package.stock_location.id}-"
           order = package.order
           ship_address = package.order.ship_address
           max_weight = get_max_weight(package)
-          contents_hash = Digest::MD5.hexdigest(package.contents.map {|content_item| content_item.variant.id.to_s + "_" + content_item.quantity.to_s }.join("|"))
-          @cache_key = "#{stock_location}#{carrier.name}-#{max_weight}-#{order.number}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+          contents_hash = Digest::MD5.hexdigest(package.contents.map {|content_item| content_item.variant.id.to_s + "_" + content_item.quantity.to_s + "_" + (content_item.variant.weight * multiplier).to_s }.join("|"))
+          @cache_key = "#{stock_location}#{carrier.name}-#{max_weight}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
         end
 
         def fetch_best_state_from_address address


### PR DESCRIPTION
1. Add weight to cache key.
2. Remove order number from cache key (two orders with the same content and ship address should always have the same shipping cost).
3. Fix broken rspec.