### PR TITLE
NEMO-7139: Caching issues relating to UPS api calls

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -272,7 +272,26 @@ module Spree
           order = package.order
           ship_address = package.order.ship_address
           contents_hash = Digest::MD5.hexdigest(package.contents.map {|content_item| content_item.variant.id.to_s + "_" + content_item.quantity.to_s + "_" + (content_item.variant.weight * multiplier).to_s }.join("|"))
-          @cache_key = "#{stock_location}-#{carrier_key}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+          if carrier_key.include? "UPS"
+            # for UPS, the API responds with all the parcel prices that the merchant
+            # has enabled. As a result, we don't want to include the parcel specific
+            # name inside the @cache_key. This would cause us to send a separate
+            # API request for each parcel when we could've just sent one request,
+            # cached it, and retrieved it from the cache for the other parcels.
+            # More info at JIRA Ticket: NEMO-7139
+
+            # For reference, self.class.to_s would be something like:
+            # Spree::Calculator::Shipping::Usps::ExpressMail or
+            # Spree::Calculator::Shipping::Ups::NextDayAir
+
+            # carrier_key would be something like:
+            # UPS-93dc3a965816028f3c32f3bb24469531 or USPS
+            @cache_key = "#{stock_location}-#{carrier_key}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+          else
+            @cache_key = "#{stock_location}-#{carrier_key}-#{ship_address.country.iso}-#{self.class.to_s}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+          end
+
+          @cache_key
         end
 
         def fetch_best_state_from_address address

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -288,7 +288,7 @@ module Spree
             # UPS-93dc3a965816028f3c32f3bb24469531 or USPS
             @cache_key = "#{stock_location}-#{carrier_key}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
           else
-            @cache_key = "#{stock_location}-#{carrier_key}-#{ship_address.country.iso}-#{self.class.to_s}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+            @cache_key = "#{stock_location}-#{carrier_key}-#{self.class.to_s}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
           end
 
           @cache_key

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -124,7 +124,9 @@ module Spree
               message = e.message
             end
 
-            raise Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
+            error = Spree::ShippingError.new("#{I18n.t(:shipping_error)}: #{message}")
+            Rails.cache.write @cache_key, error #write error to cache to prevent constant re-lookups
+            raise error
           end
 
         end
@@ -270,7 +272,7 @@ module Spree
           order = package.order
           ship_address = package.order.ship_address
           contents_hash = Digest::MD5.hexdigest(package.contents.map {|content_item| content_item.variant.id.to_s + "_" + content_item.quantity.to_s + "_" + (content_item.variant.weight * multiplier).to_s }.join("|"))
-          @cache_key = "#{stock_location}-#{carrier_key}-#{self.class.to_s}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
+          @cache_key = "#{stock_location}-#{carrier_key}-#{ship_address.country.iso}-#{fetch_best_state_from_address(ship_address)}-#{ship_address.city}-#{ship_address.zipcode}-#{contents_hash}-#{I18n.locale}".gsub(" ","")
         end
 
         def fetch_best_state_from_address address

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -25,5 +25,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
-  s.add_development_dependency 'byebug'
 end

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov'
   s.add_development_dependency 'sqlite3'
-
+  s.add_development_dependency 'byebug'
 end


### PR DESCRIPTION
JIRA: https://jira.godaddy.com/browse/NEMO-7139.

Changed the cache_key for UPS to remove references to parcel values since a UPS api call returns all parcels values. Note: the cache_key value for other shipping methods should be unaffected.

To test, grab the sha value from the latest commit(`3fba23bc89862290481cc6d5e7abac3703fc5291`) and update the reference inside `nemo/Gemfile.lock`. Additionally, make sure that `box_packer` is pinned to `1.2.3`. Without it, UPS calculations might not work. After running `bundle`, go into admin and add UPS as a second shipping method. Make sure that you check `Each product ships in a separate box` and enable all the possible parcel options (like `UPS Ground`, `UPS Three-Day Select`, etc.). 

Next, go into the storefront and checkout a product with quantity around 500. When you complete the address page of checkout, you should successfully land on the payment page with no UPS shipping methods. Before the caching change, this request would timeout since we would hit the API a bunch of times without realizing the response was the same (an error) for each parcel type. 

If you want to see what the cache_keys actually look like, you can set a byebug inside `nemo_spree/core/app/models/spree/calculator/shipping/ups/base_decorator.rb` after line 8. When you navigate to the payment page of checkout, you will drop into this byebug for each parcel type that you've enabled. You can type `n` and you will land in the `retrieve_rates_from_cache` method where you can look at the value of `cache_key(package)`. You can also step into `retrieve_rates` to see what the response from UPS is. Note that if you checkout with a product with quantity of 500, the API response will be an error which we cache so that we don't send the same request again.