### PR TITLE
NEMO-7139: making the cache_key logic more simple

### DIFF
--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -272,7 +272,7 @@ module Spree
           order = package.order
           ship_address = package.order.ship_address
           contents_hash = Digest::MD5.hexdigest(package.contents.map {|content_item| content_item.variant.id.to_s + "_" + content_item.quantity.to_s + "_" + (content_item.variant.weight * multiplier).to_s }.join("|"))
-          parcel = carrier_key.include? "UPS" ? 'Spree::Calculator::Shipping::Ups::Base' : self.class.to_s
+          parcel = (carrier_key.include? "UPS") ? 'Spree::Calculator::Shipping::Ups::Base' : self.class.to_s
           # for UPS, the API responds with all the parcel prices that the merchant
           # has enabled. As a result, we don't want to include the parcel specific
           # name inside the @cache_key. This would cause us to send a separate


### PR DESCRIPTION
JIRA: https://jira.godaddy.com/browse/NEMO-7139. Re-opened to clean up style.

Changed the cache_key for UPS to remove references to parcel values since a UPS api call returns all parcels values. Note: the cache_key value for other shipping methods should be unaffected.

To test, grab the sha value from the latest commit (`055e7b7c089716ed6bb5732a54376f6e507c6689`) and update the reference inside nemo/Gemfile.lock. Additionally, make sure that `box_packer` is pinned to `1.2.3`. Without it, UPS calculations might not work. After running bundle, go into admin and add UPS as a second shipping method. Make sure that you check Each product ships in a separate box and enable all the possible parcel options (like `UPS Ground`, `UPS Three-Day Select`, etc.).

Next, go into the storefront and checkout a product with quantity around 500. When you complete the address page of checkout, you should successfully land on the payment page with no UPS shipping methods. Before the caching change, this request would timeout since we would hit the API a bunch of times without realizing the response was the same (an error) for each parcel type.

If you want to see what the cache_keys actually look like, you can set a byebug inside `nemo_spree/core/app/models/spree/calculator/shipping/ups/base_decorator.rb` after line 8. When you navigate to the payment page of checkout, you will drop into this `byebug` for each parcel type that you've enabled. You can type `n` and you will land in the `retrieve_rates_from_cache` method where you can look at the value of `cache_key(package)`. You can also step into `retrieve_rates` to see what the response from UPS is. Note that if you checkout with a product with quantity of 500, the API response will be an error which we cache so that we don't send the same request again.