### PR TITLE
Nemo 7735 2 - Change how weight packing is handled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'spree', :github => 'godaddy/spree', :branch => '2-2-nemo-stable'
+gem 'rake', '~> 11.0'
 
 gemspec
 
@@ -11,8 +12,7 @@ group :development, :test do
   gem 'yarjuf'
   gem 'require_all'
   gem 'awesome_print'
-  gem 'rspec', '~> 2.99'
+  gem 'rspec-activemodel-mocks'
   gem 'test-unit'
   gem 'byebug'
 end
-

--- a/Rakefile
+++ b/Rakefile
@@ -25,4 +25,4 @@ task :coverage do
   Rake::Task["spec"].execute
 end
 
-task :default => [:spec]
+task default: [:spec]

--- a/app/controllers/spree/admin/product_packages_controller.rb
+++ b/app/controllers/spree/admin/product_packages_controller.rb
@@ -1,7 +1,7 @@
 module Spree
   module Admin
     class ProductPackagesController < ResourceController
-      belongs_to 'spree/product', :find_by => :slug
+      belongs_to 'spree/product', find_by: :slug
       before_filter :load_data
 
       private

--- a/app/controllers/spree/admin/products_controller_decorator.rb
+++ b/app/controllers/spree/admin/products_controller_decorator.rb
@@ -3,10 +3,10 @@ Spree::Admin::ProductsController.class_eval do
     @product = Spree::Product.friendly.find(params[:id])
     @packages = @product.product_packages
     @product.product_packages.build
-    
+
     respond_with(@object) do |format|
-    format.html { render :layout => !request.xhr? }
-      format.js { render :layout => false }
+    format.html { render layout: !request.xhr? }
+      format.js { render layout: false }
     end
   end
 end

--- a/app/controllers/spree/checkout_controller_decorator.rb
+++ b/app/controllers/spree/checkout_controller_decorator.rb
@@ -1,7 +1,7 @@
 # handle shipping errors gracefully during checkout
 Spree::CheckoutController.class_eval do
 
-  rescue_from Spree::ShippingError, :with => :handle_shipping_error
+  rescue_from Spree::ShippingError, with: :handle_shipping_error
 
   private
     def handle_shipping_error(e)

--- a/app/controllers/spree/orders_controller_decorator.rb
+++ b/app/controllers/spree/orders_controller_decorator.rb
@@ -1,7 +1,7 @@
 # handle shipping errors gracefully during order update
 Spree::OrdersController.class_eval do
 
-  rescue_from Spree::ShippingError, :with => :handle_shipping_error
+  rescue_from Spree::ShippingError, with: :handle_shipping_error
 
   private
     def handle_shipping_error(e)

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -203,6 +203,7 @@ module Spree
 
           # NOTE: this will effectively disable rate calculation for ProductPackages which
           # we do not use in Nemo. KES Apr 3, 2017 9:57 AM
+          # ProductPackages are used for items that only ever ship in their own package (box) and can not be combined
           [].each do |content_item|
             variant  = content_item.variant
             quantity = content_item.quantity

--- a/app/models/spree/calculator/shipping/active_shipping/base.rb
+++ b/app/models/spree/calculator/shipping/active_shipping/base.rb
@@ -3,6 +3,7 @@
 #
 # Digest::MD5 is used for cache_key generation.
 require 'digest/md5'
+require 'box_packer'
 require_dependency 'spree/calculator'
 
 module Spree
@@ -48,15 +49,15 @@ module Spree
         def timing(line_items)
           order = line_items.first.order
           # TODO: Figure out where stock_location is supposed to come from.
-          origin= Location.new(:country => stock_location.country.iso,
-                               :city => stock_location.city,
-                               :state => (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
-                               :zip => stock_location.zipcode)
+          origin= Location.new(country: stock_location.country.iso,
+                               city: stock_location.city,
+                               state: (stock_location.state ? stock_location.state.abbr : stock_location.state_name),
+                               zip: stock_location.zipcode)
           addr = order.ship_address
-          destination = Location.new(:country => addr.country.iso,
-                                     :state => (addr.state ? addr.state.abbr : addr.state_name),
-                                     :city => addr.city,
-                                     :zip => addr.zipcode)
+          destination = Location.new(country: addr.country.iso,
+                                     state: (addr.state ? addr.state.abbr : addr.state_name),
+                                     city: addr.city,
+                                     zip: addr.zipcode)
           timings_result = Rails.cache.fetch(cache_key(package)+"-timings") do
             retrieve_timings(origin, destination, packages(order))
           end
@@ -156,41 +157,43 @@ module Spree
           end
         end
 
+        def expand_package_contents(package)
+          exploded_package = Spree::Stock::Package.new(package.stock_location, package.order)
+          package.contents.each do |content_item|
+            content_item.quantity.times do
+              exploded_package.add(content_item.line_item, 1, content_item.state)
+            end
+          end
+          exploded_package
+        end
+
         def convert_package_to_weights_array(package)
           multiplier = Spree::ActiveShipping::Config[:unit_multiplier]
           default_weight = Spree::ActiveShipping::Config[:default_weight]
           max_weight = get_max_weight(package)
+          if max_weight <= 0
+            max_weight = 999_999_999
+          end
 
-          weights = package.contents.map do |content_item|
+          item_weights = expand_package_contents(package).contents.map do |content_item|
             item_weight = content_item.variant.weight.to_f
             item_weight = default_weight if item_weight <= 0
             item_weight *= multiplier
-
-            quantity = content_item.quantity
-            if max_weight <= 0
-              item_weight * quantity
-            elsif item_weight == 0
-              0
-            else
-              if item_weight < max_weight
-                max_quantity = (max_weight/item_weight).floor
-                if quantity < max_quantity
-                  item_weight * quantity
-                else
-                  new_items = []
-                  while quantity > 0 do
-                    new_quantity = [max_quantity, quantity].min
-                    new_items << (item_weight * new_quantity)
-                    quantity -= new_quantity
-                  end
-                  new_items
-                end
-              else
-                raise Spree::ShippingError.new("#{I18n.t(:shipping_error)}: The maximum per package weight for the selected service from the selected country is #{max_weight} ounces.")
-              end
-            end
           end
-          weights.flatten.compact.sort
+          item_weights.sort!
+
+          # pack items by weight ignorning size
+          packer = BoxPacker.container [999,999,999], weight_limit: max_weight do
+            item_weights.each { |item_weight| add_item([0,0,0], weight: item_weight, quantity: 1) }
+            pack!
+          end
+
+          unless packer.packed_successfully
+            raise Spree::ShippingError.new("#{I18n.t(:shipping_error)}: The maximum per package weight for the selected service from the selected country is #{max_weight} ounces.")
+          end
+
+          weights = packer.packings.map { |packing| packing.sum(&:weight) }
+          weights.sort
         end
 
         def convert_package_to_item_packages_array(package)
@@ -198,7 +201,9 @@ module Spree
           max_weight = get_max_weight(package)
           packages = []
 
-          package.contents.each do |content_item|
+          # NOTE: this will effectively disable rate calculation for ProductPackages which
+          # we do not use in Nemo. KES Apr 3, 2017 9:57 AM
+          [].each do |content_item|
             variant  = content_item.variant
             quantity = content_item.quantity
             product  = variant.product
@@ -226,22 +231,22 @@ module Spree
           item_specific_packages = convert_package_to_item_packages_array(package)
 
           if max_weight <= 0
-            packages << Package.new(weights.sum, [], :units => units)
+            packages << Package.new(weights.sum, [], units: units)
           else
             package_weight = 0
             weights.each do |content_weight|
               if package_weight + content_weight <= max_weight
                 package_weight += content_weight
               else
-                packages << Package.new(package_weight, [], :units => units)
+                packages << Package.new(package_weight, [], units: units)
                 package_weight = content_weight
               end
             end
-            packages << Package.new(package_weight, [], :units => units) if package_weight > 0
+            packages << Package.new(package_weight, [], units: units) if package_weight > 0
           end
 
           item_specific_packages.each do |package|
-            packages << Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], :units => :imperial)
+            packages << Package.new(package.at(0), [package.at(1), package.at(2), package.at(3)], units: :imperial)
           end
 
           packages
@@ -291,10 +296,10 @@ module Spree
         end
 
         def build_location address
-          Location.new(:country => address.country.iso,
-                       :state   => fetch_best_state_from_address(address),
-                       :city    => address.city,
-                       :zip     => address.zipcode)
+          Location.new(country: address.country.iso,
+                       state:   fetch_best_state_from_address(address),
+                       city:    address.city,
+                       zip:     address.zipcode)
         end
 
         def build_locations origin, destination

--- a/app/models/spree/calculator/shipping/canada_post/base.rb
+++ b/app/models/spree/calculator/shipping/canada_post/base.rb
@@ -6,8 +6,8 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
           canada_post_options = {
-            :login  => Spree::ActiveShipping::Config[:canada_post_login],
-            :french => (I18n.locale.to_sym == :fr)
+            login:  Spree::ActiveShipping::Config[:canada_post_login],
+            french: (I18n.locale.to_sym == :fr)
           }
           ActiveMerchant::Shipping::CanadaPost.new(canada_post_options)
         end

--- a/app/models/spree/calculator/shipping/fedex/base.rb
+++ b/app/models/spree/calculator/shipping/fedex/base.rb
@@ -6,11 +6,11 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
         def carrier
           carrier_details = {
-            :key => Spree::ActiveShipping::Config[:fedex_key],
-            :password => Spree::ActiveShipping::Config[:fedex_password],
-            :account => Spree::ActiveShipping::Config[:fedex_account],
-            :login => Spree::ActiveShipping::Config[:fedex_login],
-            :test => Spree::ActiveShipping::Config[:test_mode]
+            key: Spree::ActiveShipping::Config[:fedex_key],
+            password: Spree::ActiveShipping::Config[:fedex_password],
+            account: Spree::ActiveShipping::Config[:fedex_account],
+            login: Spree::ActiveShipping::Config[:fedex_login],
+            test: Spree::ActiveShipping::Config[:test_mode]
           }
 
           ActiveMerchant::Shipping::FedEx.new(carrier_details)

--- a/app/models/spree/calculator/shipping/ups/base.rb
+++ b/app/models/spree/calculator/shipping/ups/base.rb
@@ -19,18 +19,18 @@ module Spree
         def carrier_details
           @carrier_details ||= begin
             details = {
-              :login => Spree::ActiveShipping::Config[:ups_login],
-              :password => Spree::ActiveShipping::Config[:ups_password],
-              :key => Spree::ActiveShipping::Config[:ups_key],
-              :test => Spree::ActiveShipping::Config[:test_mode]
+              login: Spree::ActiveShipping::Config[:ups_login],
+              password: Spree::ActiveShipping::Config[:ups_password],
+              key: Spree::ActiveShipping::Config[:ups_key],
+              test: Spree::ActiveShipping::Config[:test_mode]
             }
 
             if Spree::ActiveShipping::Config[:ups_rate_type] == 'negotiated' && shipper_number = Spree::ActiveShipping::Config[:shipper_number]
-              details.merge!(:origin_account => shipper_number)
+              details.merge!(origin_account: shipper_number)
             end
 
             if ups_pickup_type = Spree::ActiveShipping::Config[:ups_pickup_type]
-              details.merge!(:pickup_type => ups_pickup_type)
+              details.merge!(pickup_type: ups_pickup_type)
             end
 
             details

--- a/app/models/spree/calculator/shipping/usps/base.rb
+++ b/app/models/spree/calculator/shipping/usps/base.rb
@@ -4,14 +4,14 @@ module Spree
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
 
         SERVICE_CODE_PREFIX = {
-          :international => 'intl',
+          international: 'intl',
           :domestic      => 'dom'
         }
 
         def carrier
           carrier_details = {
-            :login => Spree::ActiveShipping::Config[:usps_login],
-            :test => Spree::ActiveShipping::Config[:test_mode]
+            login: Spree::ActiveShipping::Config[:usps_login],
+            test: Spree::ActiveShipping::Config[:test_mode]
           }
 
           ActiveMerchant::Shipping::USPS.new(carrier_details)

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -1,4 +1,4 @@
 # Add product packages relation
 Spree::LineItem.class_eval do
-  has_many :product_packages, :through => :product
+  has_many :product_packages, through: :product
 end

--- a/app/models/spree/product_decorator.rb
+++ b/app/models/spree/product_decorator.rb
@@ -1,6 +1,6 @@
 # Add product packages relation
 Spree::Product.class_eval do
-  has_many :product_packages, :dependent => :destroy
+  has_many :product_packages, dependent: :destroy
 
-  accepts_nested_attributes_for :product_packages, :allow_destroy => true, :reject_if => lambda { |pp| pp[:weight].blank? or Integer(pp[:weight]) < 1 }
+  accepts_nested_attributes_for :product_packages, allow_destroy: true, reject_if: lambda { |pp| pp[:weight].blank? or Integer(pp[:weight]) < 1 }
 end

--- a/app/models/spree/product_package.rb
+++ b/app/models/spree/product_package.rb
@@ -3,8 +3,8 @@ module Spree
     belongs_to :product
 
     validates :length, :width, :height, :weight,
-              :numericality => { :only_integer => true,
-                                 :message => Spree.t('validation.must_be_int'),
-                                 :greater_than => 0 }
+              numericality: { only_integer: true,
+                              message: Spree.t('validation.must_be_int'),
+                              greater_than: 0 }
   end
 end

--- a/app/overrides/spree/admin/shared/_product_tabs/add_product_packages_tab.html.erb.deface
+++ b/app/overrides/spree/admin/shared/_product_tabs/add_product_packages_tab.html.erb.deface
@@ -2,6 +2,6 @@
 
 <% if can? :update, @product.product_packages.build %>
   <li<%== ' class=\"active\"' if current == 'Product Packages' %>>
-     <%= link_to Spree.t(:product_packages), admin_product_product_packages_url(@product), :class => 'fa fa-truck' %>
+     <%= link_to Spree.t(:product_packages), admin_product_product_packages_url(@product), class: 'fa fa-truck' %>
   </li>
 <% end %>

--- a/app/views/spree/admin/active_shipping_settings/edit.html.erb
+++ b/app/views/spree/admin/active_shipping_settings/edit.html.erb
@@ -1,10 +1,10 @@
-<%= render :partial => 'spree/admin/shared/configuration_menu' %>
+<%= render partial: 'spree/admin/shared/configuration_menu' %>
 
 <% content_for :page_title do %>
   <%= Spree.t(:active_shipping_settings) %>
 <% end %>
 
-<%= form_tag admin_active_shipping_settings_path, :method => :put  do |form| %>
+<%= form_tag admin_active_shipping_settings_path, method: :put  do |form| %>
   <div id="preferences" data-hook>
     <fieldset class="general no-border-top">
       <div class="row">
@@ -15,7 +15,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -28,7 +28,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -44,7 +44,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -57,7 +57,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -73,7 +73,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -86,7 +86,7 @@
                 type = @config.preference_type(key) %>
                 <div class="field">
                   <%= label_tag(key, Spree.t(key) + ': ') + tag(:br) if type != :boolean %>
-                  <%= preference_field_tag(key, @config[key], :type => type) %>
+                  <%= preference_field_tag(key, @config[key], type: type) %>
                   <%= label_tag(key, Spree.t(key)) + tag(:br) if type == :boolean %>
                 </div>
             <% end %>
@@ -97,7 +97,7 @@
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button Spree.t(:update), 'icon-refresh' %>
         <span class="or"><%= Spree.t(:or) %></span>
-        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), edit_admin_active_shipping_settings_url, :class => 'button' %>
+        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), edit_admin_active_shipping_settings_url, class: 'button' %>
       </div>
 
     </fieldset>

--- a/app/views/spree/admin/product_packages/edit.html.erb
+++ b/app/views/spree/admin/product_packages/edit.html.erb
@@ -1,13 +1,13 @@
-<%= form_for [:admin, @product, @product_package], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product, @product_package], html: { multipart: true } do |f| %>
   <fieldset data-hook="edit_product_package">
     <legend align="center"><%= Spree.t(:edit_package) %></legend>
 
-      <%= render :partial => 'form', :locals => { :f => f } %>
+      <%= render partial: 'form', locals: { f: f } %>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button Spree.t(:update), 'icon-refresh' %>
         <span class="or"><%= t(:or) %></span>
-        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), admin_product_product_packages_url(@product), :id => 'cancel_link', :class => 'button' %>
+        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), admin_product_product_packages_url(@product), id: 'cancel_link', class: 'button' %>
       </div>
   </fieldset>
 <% end %>

--- a/app/views/spree/admin/product_packages/index.html.erb
+++ b/app/views/spree/admin/product_packages/index.html.erb
@@ -1,13 +1,13 @@
 <% content_for :page_actions do %>
-  <li><%= link_to_with_icon('icon-plus', Spree.t(:new_package), new_admin_product_product_package_url(@product), :id => 'new_product_package_link', :class => 'button') %></li>
+  <li><%= link_to_with_icon('icon-plus', Spree.t(:new_package), new_admin_product_product_package_url(@product), id: 'new_product_package_link', class: 'button') %></li>
 <% end %>
 
 <% content_for :head do %>
   <%= javascript_include_tag 'admin/product_packages/index.js' %>
 <% end %>
 
-<%= render :partial => 'spree/admin/shared/product_sub_menu' %>
-<%= render :partial => 'spree/admin/shared/product_tabs', :locals => { :current => 'Product Packages' } %>
+<%= render partial: 'spree/admin/shared/product_sub_menu' %>
+<%= render partial: 'spree/admin/shared/product_tabs', locals: { current: 'Product Packages' } %>
 
 <div id="product_packages" data-hook></div>
 
@@ -34,9 +34,9 @@
           <td><%= package.height %></td>
           <td><%= package.weight %></td>
           <td class="actions">
-            <%= link_to_with_icon 'icon-edit', Spree.t(:edit), edit_admin_product_product_package_url(@product, package), :class => "edit", :no_text => true, :data => {:action => 'edit'} %>
+            <%= link_to_with_icon 'icon-edit', Spree.t(:edit), edit_admin_product_product_package_url(@product, package), class: "edit", no_text: true, data: {action: 'edit'} %>
             &nbsp;
-            <%= link_to_delete package, { :url => admin_product_product_package_url(@product, package), :no_text => true }%>
+            <%= link_to_delete package, { url: admin_product_product_package_url(@product, package), no_text: true }%>
           </td>
         </tr>
       <% end %>

--- a/app/views/spree/admin/product_packages/new.html.erb
+++ b/app/views/spree/admin/product_packages/new.html.erb
@@ -1,13 +1,13 @@
-<%= form_for [:admin, @product, @product_package], :html => { :multipart => true } do |f| %>
+<%= form_for [:admin, @product, @product_package], html: { multipart: true } do |f| %>
   <fieldset data-hook="new_product_package">
     <legend align="center"><%= Spree.t(:new_package) %></legend>
 
-      <%= render :partial => 'form', :locals => { :f => f } %>
+      <%= render partial: 'form', locals: { f: f } %>
 
       <div class="form-buttons filter-actions actions" data-hook="buttons">
         <%= button Spree.t(:update), 'icon-refresh' %>
         <span class="or"><%= t(:or) %></span>
-        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), admin_product_product_packages_url(@product), :id => 'cancel_link', :class => 'button' %>
+        <%= link_to_with_icon 'icon-remove', Spree.t(:cancel), admin_product_product_packages_url(@product), id: 'cancel_link', class: 'button' %>
       </div>
   </fieldset>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,8 @@
 Spree::Core::Engine.add_routes do
   namespace :admin do
-    resource :active_shipping_settings, :only => ['show', 'update', 'edit']
+    resource :active_shipping_settings, only: ['show', 'update', 'edit']
 
-    resources :products, :only => [] do
+    resources :products, only: [] do
       resources :product_packages
     end
   end

--- a/lib/spree/active_shipping/ups_override.rb
+++ b/lib/spree/active_shipping/ups_override.rb
@@ -228,9 +228,9 @@ module Spree
                 guaranteed_code = service_summary.get_text('Guaranteed/Code').to_s
                 business_transit_days = service_summary.get_text('EstimatedArrival/BusinessTransitDays').to_s
                 date = service_summary.get_text('EstimatedArrival/Date').to_s
-                rate_estimates[service_name_for(origin, service_code_2)] = {:service_code => service_code, :service_code_2 => service_code_2, :service_desc => service_desc,
-                    :guaranteed_code => guaranteed_code, :business_transit_days => business_transit_days,
-                    :date => date}
+                rate_estimates[service_name_for(origin, service_code_2)] = { service_code: service_code, service_code_2: service_code_2, service_desc: service_desc,
+                    guaranteed_code: guaranteed_code, business_transit_days: business_transit_days,
+                    date: date }
               end
             end
             return rate_estimates
@@ -253,17 +253,17 @@ module Spree
                 negotiated_rate = rated_shipment.get_text('NegotiatedRates/NetSummaryCharges/GrandTotal/MonetaryValue').to_s
                 total_price     = negotiated_rate.blank? ? rated_shipment.get_text('TotalCharges/MonetaryValue').to_s.to_f : negotiated_rate.to_f
                 currency        = negotiated_rate.blank? ? rated_shipment.get_text('TotalCharges/CurrencyCode').to_s : rated_shipment.get_text('NegotiatedRates/NetSummaryCharges/GrandTotal/CurrencyCode').to_s
-                
+
                 rate_estimates << ActiveMerchant::Shipping::RateEstimate.new(origin, destination, ActiveMerchant::Shipping::UPS.name,
                                     service_name_for(origin, service_code),
-                                    :total_price => total_price,
-                                    :currency => currency,
-                                    :service_code => service_code,
-                                    :packages => packages
+                                    total_price: total_price,
+                                    currency: currency,
+                                    service_code: service_code,
+                                    packages: packages
                                     )
               end
             end
-            ActiveMerchant::Shipping::RateResponse.new(success, message, Hash.from_xml(response).values.first, :rates => rate_estimates, :xml => response, :request => last_request)
+            ActiveMerchant::Shipping::RateResponse.new(success, message, Hash.from_xml(response).values.first, rates: rate_estimates, xml: response, request: last_request)
           end
         end
       end

--- a/lib/spree/active_shipping_configuration.rb
+++ b/lib/spree/active_shipping_configuration.rb
@@ -1,31 +1,31 @@
 class Spree::ActiveShippingConfiguration < Spree::Preferences::Configuration
 
-  preference :ups_login, :string, :default => "aunt_judy"
-  preference :ups_password, :string, :default => "secret"
-  preference :ups_key, :string, :default => "developer_key"
-  preference :ups_rate_type, :string, :default => 'negotiated'
-  preference :shipper_number, :string, :default => nil
-  preference :ups_pickup_type, :string, :default => :daily_pickup
+  preference :ups_login, :string, default: "aunt_judy"
+  preference :ups_password, :string, default: "secret"
+  preference :ups_key, :string, default: "developer_key"
+  preference :ups_rate_type, :string, default: 'negotiated'
+  preference :shipper_number, :string, default: nil
+  preference :ups_pickup_type, :string, default: :daily_pickup
 
-  preference :fedex_login, :string, :default => "meter_no"
-  preference :fedex_password, :string, :default => "special_sha1_looking_thing_sent_via_email"
-  preference :fedex_account, :string, :default => "account_no"
-  preference :fedex_key, :string, :default => "authorization_key"
+  preference :fedex_login, :string, default: "meter_no"
+  preference :fedex_password, :string, default: "special_sha1_looking_thing_sent_via_email"
+  preference :fedex_account, :string, default: "account_no"
+  preference :fedex_key, :string, default: "authorization_key"
 
-  preference :usps_login, :string, :default => "aunt_judy"
+  preference :usps_login, :string, default: "aunt_judy"
 
-  preference :canada_post_login, :string, :default => "canada_post_login"
+  preference :canada_post_login, :string, default: "canada_post_login"
 
-  preference :origin_country, :string, :default => "US"
-  preference :origin_state, :string, :default => "PA"
-  preference :origin_city, :string, :default => "University Park"
-  preference :origin_zip, :string, :default => "16802"
+  preference :origin_country, :string, default: "US"
+  preference :origin_state, :string, default: "PA"
+  preference :origin_city, :string, default: "University Park"
+  preference :origin_zip, :string, default: "16802"
 
-  preference :units, :string, :default => "imperial"
-  preference :unit_multiplier, :decimal, :default => 16 # 16 oz./lb - assumes variant weights are in lbs
-  preference :default_weight, :integer, :default => 0 # 16 oz./lb - assumes variant weights are in lbs
+  preference :units, :string, default: "imperial"
+  preference :unit_multiplier, :decimal, default: 16 # 16 oz./lb - assumes variant weights are in lbs
+  preference :default_weight, :integer, default: 0 # 16 oz./lb - assumes variant weights are in lbs
   preference :handling_fee, :integer
-  preference :max_weight_per_package, :integer, :default => 0 # 0 means no limit
+  preference :max_weight_per_package, :integer, default: 0 # 0 means no limit
 
-  preference :test_mode, :boolean, :default => false
+  preference :test_mode, :boolean, default: false
 end

--- a/lib/spree_active_shipping/engine.rb
+++ b/lib/spree_active_shipping/engine.rb
@@ -3,7 +3,7 @@ end
 module SpreeActiveShippingExtension
   class Engine < Rails::Engine
 
-    initializer "spree.active_shipping.preferences", :before => :load_config_initializers do |app|
+    initializer "spree.active_shipping.preferences", before: :load_config_initializers do |app|
       Spree::ActiveShipping::Config = Spree::ActiveShippingConfiguration.new
     end
 
@@ -40,7 +40,7 @@ module SpreeActiveShippingExtension
     end
 
         # sets the manifests / assets to be precompiled, even when initialize_on_precompile is false
-    initializer "spree.assets.precompile", :group => :all do |app|
+    initializer "spree.assets.precompile", group: :all do |app|
       app.config.assets.precompile += %w[
         admin/product_packages/new.js
         admin/product_packages/edit.js

--- a/spec/controllers/admin/active_shipping_settings_controller_spec.rb
+++ b/spec/controllers/admin/active_shipping_settings_controller_spec.rb
@@ -6,8 +6,8 @@ describe Spree::Admin::ActiveShippingSettingsController do
   context '#edit' do
     it 'should assign a Spree::ActiveShippingConfiguration and render the view' do
       spree_get :edit
-      assigns(:config).should be_an_instance_of(Spree::ActiveShippingConfiguration)
-      response.should render_template('edit')
+      expect(assigns(:config)).to be_an_instance_of(Spree::ActiveShippingConfiguration)
+      expect(response).to render_template('edit')
     end
   end
 
@@ -19,28 +19,28 @@ describe Spree::Admin::ActiveShippingSettingsController do
         it "should allow us to set the value of #{name}" do
           new_val = SecureRandom.random_number(100)
           spree_post :update, name => new_val
-          Spree::ActiveShippingConfiguration.new.send("preferred_#{name}").should eq(new_val)
-          response.should redirect_to(spree.edit_admin_active_shipping_settings_path)
+          expect(Spree::ActiveShippingConfiguration.new.send("preferred_#{name}")).to eq(new_val)
+          expect(response).to redirect_to(spree.edit_admin_active_shipping_settings_path)
         end
       when :string
         it "should allow us to set the value of #{name}" do
           new_val = SecureRandom.hex(5)
           spree_post :update, name => new_val
-          Spree::ActiveShippingConfiguration.new.send("preferred_#{name}").should eq(new_val)
-          response.should redirect_to(spree.edit_admin_active_shipping_settings_path)
+          expect(Spree::ActiveShippingConfiguration.new.send("preferred_#{name}")).to eq(new_val)
+          expect(response).to redirect_to(spree.edit_admin_active_shipping_settings_path)
         end
       when :boolean
         it "should allow us to switch the value of #{name}" do
           spree_post :update, name => !orig_val
-          Spree::ActiveShippingConfiguration.new.send("preferred_#{name}").should eq(!orig_val)
-          response.should redirect_to(spree.edit_admin_active_shipping_settings_path)
+          expect(Spree::ActiveShippingConfiguration.new.send("preferred_#{name}")).to eq(!orig_val)
+          expect(response).to redirect_to(spree.edit_admin_active_shipping_settings_path)
         end
       end
     end
 
     it "doesn't product an error when passed an invalid parameter name" do
       spree_post :update, 'not_real_parameter_name' => 'not_real'
-      response.should redirect_to(spree.edit_admin_active_shipping_settings_path)
+      expect(response).to redirect_to(spree.edit_admin_active_shipping_settings_path)
     end
   end
 end

--- a/spec/controllers/admin/product_packages_controller_spec.rb
+++ b/spec/controllers/admin/product_packages_controller_spec.rb
@@ -8,9 +8,9 @@ describe Spree::Admin::ProductPackagesController do
 
     it 'should find ProductPackages for the product and render the view' do
       spree_get :index, product_id: product.slug
-      assigns(:product).should eq(product)
-      response.should be_ok
-      response.should render_template('index')
+      expect(assigns(:product)).to eq(product)
+      expect(response).to be_ok
+      expect(response).to render_template('index')
     end
   end
 
@@ -24,13 +24,13 @@ describe Spree::Admin::ProductPackagesController do
       new_height = SecureRandom.random_number(19) + 1
       new_weight = SecureRandom.random_number(19) + 1
       spree_post :update, product_id: product.slug, id: product_package.id,
-                          product_package: { length: new_length, width: new_width, 
+                          product_package: { length: new_length, width: new_width,
                                              height: new_height, weight: new_weight }
       product_package.reload
-      product_package.length.should eq(new_length)
-      product_package.width.should eq(new_width)
-      product_package.height.should eq(new_height)
-      product_package.weight.should eq(new_weight)
+      expect(product_package.length).to eq(new_length)
+      expect(product_package.width).to eq(new_width)
+      expect(product_package.height).to eq(new_height)
+      expect(product_package.weight).to eq(new_weight)
     end
   end
 end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -8,7 +8,7 @@ module ActiveShipping
 
     let(:address) { FactoryGirl.create(:address) }
     let!(:order) do
-      order = FactoryGirl.create(:order_with_line_items, :ship_address => address, :line_items_count => 2)
+      order = FactoryGirl.create(:order_with_line_items, ship_address: address, :line_items_count => 2)
       order.line_items.first.tap do |line_item|
         line_item.quantity = 2
         line_item.variant.save
@@ -28,16 +28,16 @@ module ActiveShipping
       order
     end
 
-    let(:carrier) { ActiveMerchant::Shipping::USPS.new(:login => "FAKEFAKEFAKE") }
+    let(:carrier) { ActiveMerchant::Shipping::USPS.new(login: "FAKEFAKEFAKE") }
     let(:calculator) { Spree::Calculator::Shipping::Usps::ExpressMail.new }
-    let(:response) { double('response', :rates => rates, :params => {}) }
+    let(:response) { double('response', rates: rates, :params => {}) }
     let(:package) { order.shipments.first.to_package }
 
     before(:each) do
       order.create_proposed_shipments
       expect(order.shipments.count).to eq 1
-      Spree::ActiveShipping::Config.set(:units => "imperial")
-      Spree::ActiveShipping::Config.set(:unit_multiplier => 1)
+      Spree::ActiveShipping::Config.set(units: "imperial")
+      Spree::ActiveShipping::Config.set(unit_multiplier: 1)
       allow(calculator).to receive(:carrier).and_return(carrier)
       Rails.cache.clear
     end
@@ -45,7 +45,7 @@ module ActiveShipping
     describe "available" do
       context "when rates are available" do
         let(:rates) do
-          [ double('rate', :service_name => 'Service', :service_code => 3, :price => 1) ]
+          [ double('rate', service_name: 'Service', :service_code => 3, :price => 1) ]
         end
 
         before do
@@ -88,7 +88,7 @@ module ActiveShipping
     describe "compute" do
       it "should use the carrier supplied in the initializer" do
         stub_request(:get, /http:\/\/production.shippingapis.com\/ShippingAPI.dll.*/).
-          to_return(:body => fixture(:normal_rates_request))
+          to_return(body: fixture(:normal_rates_request))
         expect(calculator.compute(package)).to eq 14.1
       end
 
@@ -101,7 +101,7 @@ module ActiveShipping
 
       xit "should create a package with the correct total weight in ounces" do
         # (10 * 2 + 5.25 * 1) * 16 = 404
-        expect(Package).to receive(:new).with(404, [], :units => :imperial)
+        expect(Package).to receive(:new).with(404, [], units: :imperial)
         calculator.compute(package)
       end
 
@@ -124,7 +124,7 @@ module ActiveShipping
 
         xit "should include handling_fee when configured" do
           expect(calculator.class).to receive(:description).and_return("Super Fast")
-          Spree::ActiveShipping::Config.set(:handling_fee => 100)
+          Spree::ActiveShipping::Config.set(handling_fee: 100)
           rate = calculator.compute(package)
           expect(rate).to eq 10.99
         end

--- a/spec/models/active_shipping_calculator_spec.rb
+++ b/spec/models/active_shipping_calculator_spec.rb
@@ -35,10 +35,10 @@ module ActiveShipping
 
     before(:each) do
       order.create_proposed_shipments
-      order.shipments.count.should == 1
+      expect(order.shipments.count).to eq 1
       Spree::ActiveShipping::Config.set(:units => "imperial")
       Spree::ActiveShipping::Config.set(:unit_multiplier => 1)
-      calculator.stub(:carrier).and_return(carrier)
+      allow(calculator).to receive(:carrier).and_return(carrier)
       Rails.cache.clear
     end
 
@@ -49,16 +49,16 @@ module ActiveShipping
         end
 
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          expect(carrier).to receive(:find_rates).and_return(response)
         end
 
         it "should return true" do
-          calculator.available?(package).should be(true)
+          expect(calculator.available?(package)).to be(true)
         end
 
         it "should use zero as a valid weight for service" do
-          calculator.stub(:max_weight_for_country).and_return(0)
-          calculator.available?(package).should be(true)
+          allow(calculator).to receive(:max_weight_for_country).and_return(0)
+          expect(calculator.available?(package)).to eq(true)
         end
       end
 
@@ -66,21 +66,21 @@ module ActiveShipping
         let(:rates) { [] }
 
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          expect(carrier).to receive(:find_rates).and_return(response)
         end
 
         it "should return false" do
-          calculator.available?(package).should be(false)
+          expect(calculator.available?(package)).to be(false)
         end
       end
 
       context "when there is an error retrieving the rates" do
         before do
-          carrier.should_receive(:find_rates).and_raise(ActiveMerchant::ActiveMerchantError)
+          expect(carrier).to receive(:find_rates).and_raise(ActiveMerchant::ActiveMerchantError)
         end
 
         it "should return false" do
-          calculator.available?(package).should be(false)
+          expect(calculator.available?(package)).to be(false)
         end
       end
     end
@@ -89,7 +89,7 @@ module ActiveShipping
       it "should use the carrier supplied in the initializer" do
         stub_request(:get, /http:\/\/production.shippingapis.com\/ShippingAPI.dll.*/).
           to_return(:body => fixture(:normal_rates_request))
-        calculator.compute(package).should == 14.1
+        expect(calculator.compute(package)).to eq 14.1
       end
 
       xit "should ignore variants that have a nil weight" do
@@ -101,45 +101,45 @@ module ActiveShipping
 
       xit "should create a package with the correct total weight in ounces" do
         # (10 * 2 + 5.25 * 1) * 16 = 404
-        Package.should_receive(:new).with(404, [], :units => :imperial)
+        expect(Package).to receive(:new).with(404, [], :units => :imperial)
         calculator.compute(package)
       end
 
       xit "should check the cache first before finding rates" do
         Rails.cache.fetch(calculator.send(:cache_key, order)) { Hash.new }
-        carrier.should_not_receive(:find_rates)
+        expect(carrier).not_to receive(:find_rates)
         calculator.compute(package)
       end
 
       context "with valid response" do
         before do
-          carrier.should_receive(:find_rates).and_return(response)
+          expect(carrier).to receive(:find_rates).and_return(response)
         end
 
         xit "should return rate based on calculator's service_name" do
-          calculator.class.should_receive(:description).and_return("Super Fast")
+          expect(calculator.class).to receive(:description).and_return("Super Fast")
           rate = calculator.compute(package)
-          rate.should == 9.99
+          expect(rate).to eq 9.99
         end
 
         xit "should include handling_fee when configured" do
-          calculator.class.should_receive(:description).and_return("Super Fast")
+          expect(calculator.class).to receive(:description).and_return("Super Fast")
           Spree::ActiveShipping::Config.set(:handling_fee => 100)
           rate = calculator.compute(package)
-          rate.should == 10.99
+          expect(rate).to eq 10.99
         end
 
         xit "should return nil if service_name is not found in rate_hash" do
-          calculator.class.should_receive(:description).and_return("Extra-Super Fast")
+          expect(calculator.class).to receive(:description).and_return("Extra-Super Fast")
           rate = calculator.compute(package)
-          rate.should be_nil
+          expect(rate).to be_nil
         end
       end
     end
 
     describe "service_name" do
       it "should return description when not defined" do
-        calculator.class.service_name.should == calculator.description
+        expect(calculator.class.service_name).to eq calculator.description
       end
     end
 
@@ -154,32 +154,32 @@ module ActiveShipping
       end
 
       it "should include carrier name" do
-        carrier.stub(:name).and_return "#{carrier.name}-changed"
+        allow(carrier).to receive(:name).and_return "#{carrier.name}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
 
       it "should include calculator class" do
-        calculator.stub(:class).and_return "#{calculator.class.to_s}-changed"
+        allow(calculator).to receive(:class).and_return "#{calculator.class.to_s}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
 
       it "should include ship address country" do
-        package.order.ship_address.stub_chain(:country, :iso).and_return "#{package.order.ship_address.country.iso}-changed"
+        allow(package.order.ship_address).to receive_message_chain(:country, :iso).and_return "#{package.order.ship_address.country.iso}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
 
       it "should include ship address state" do
-        package.order.ship_address.stub_chain(:state, :abbr).and_return "#{package.order.ship_address.state.abbr}-changed"
+        allow(package.order.ship_address).to receive_message_chain(:state, :abbr).and_return "#{package.order.ship_address.state.abbr}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
 
       it "should include ship address city" do
-        package.order.ship_address.stub(:city).and_return "#{package.order.ship_address.city}-changed"
+        allow(package.order.ship_address).to receive(:city).and_return "#{package.order.ship_address.city}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
 
       it "should include ship address zipcode" do
-        package.order.ship_address.stub(:zipcode).and_return "#{package.order.ship_address.zipcode}-changed"
+        allow(package.order.ship_address).to receive(:zipcode).and_return "#{package.order.ship_address.zipcode}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
 
@@ -199,7 +199,7 @@ module ActiveShipping
       end
 
       it "should include I18n locale" do
-        I18n.stub(:locale).and_return "#{I18n.locale}-changed"
+        allow(I18n).to receive(:locale).and_return "#{I18n.locale}-changed"
         expect(calculator.send(:cache_key, package)).not_to eq(@cache_key)
       end
     end

--- a/spec/models/weight_limits_spec.rb
+++ b/spec/models/weight_limits_spec.rb
@@ -4,82 +4,112 @@ include ActiveMerchant::Shipping
 module ActiveShipping
   describe Spree::ShippingCalculator do
 
-    let(:country) { mock_model Spree::Country, :iso => "CA", :state_name => "Quebec", :state => nil }
-    let(:address) { mock_model Spree::Address, :country => country, :state_name => country.state_name, :city => "Montreal", :zipcode => "H2B", :state => nil }
-    let(:usa) { FactoryGirl.create(:country, :name => "USA", :iso => "US") }
+    let(:country) { mock_model Spree::Country, iso: "CA", state_name: "Quebec", state: nil }
+    let(:address) { mock_model Spree::Address, country: country, state_name: country.state_name, city: "Montreal", zipcode: "H2B", state: nil }
+    let(:usa) { FactoryGirl.create(:country, name: "USA", iso: "US") }
     let(:state) { FactoryGirl.create(:state, country: usa, abbr: 'MD', name: 'Maryland')}
-    let(:us_address) { FactoryGirl.create(:address, :country => usa, :state => state, :city => "Chevy Chase", :zipcode => "20815") }
-    let(:package1) { mock_model(Spree::ProductPackage, :length => 12, :width => 24, :height => 47, :weight => 36) }
-    let(:package2) { mock_model(Spree::ProductPackage, :length => 6, :width => 6, :height => 51, :weight => 43) }
-    let(:variant1) { build(:variant, :weight => 20.0) }
-    let(:variant2) { build(:variant, :weight => 5.25) }
-    let(:variant3) { build(:variant, :weight => 29.0) }
-    let(:variant4) { build(:variant, :weight => 100.0) }
-    let(:variant5) { build(:variant, :weight => 0) }
-    let(:variant6) { build(:variant, :weight => -1.0) }
-    let(:variant7) { double(Spree::Variant, :weight => 29.0, :product => mock_model(Spree::Product, :product_packages => [package1, package2])) }
-    let(:variant8) { double(Spree::Variant, :weight => 5.25, :product => mock_model(Spree::Product, :product_packages => [])) }
+    let(:us_address) { FactoryGirl.create(:address, country: usa, state: state, city: "Chevy Chase", zipcode: "20815") }
+    let(:package1) { mock_model(Spree::ProductPackage, length: 12, width: 24, height: 47, weight: 36) }
+    let(:package2) { mock_model(Spree::ProductPackage, length: 6, width: 6, height: 51, weight: 43) }
+    let(:variant1) { build(:variant, weight: 20.0) }
+    let(:variant2) { build(:variant, weight: 5.25) }
+    let(:variant3) { build(:variant, weight: 29.0) }
+    let(:variant4) { build(:variant, weight: 100.0) }
+    let(:variant5) { build(:variant, weight: 0) }
+    let(:variant6) { build(:variant, weight: -1.0) }
+    let(:variant7) { double(Spree::Variant, weight: 29.0, product: mock_model(Spree::Product, product_packages: [package1, package2])) }
+    let(:variant8) { double(Spree::Variant, weight: 5.25, product: mock_model(Spree::Product, product_packages: [])) }
     let(:california) { FactoryGirl.create(:state, country: usa, abbr: 'CA', name: 'California') }
-    let(:stock_location) { FactoryGirl.create(:stock_location, :address1 => '1313 S Harbor Blvd', :address2 => '', :city => 'Anaheim', :state => california, :country => usa, :phone => '7147814000', :active => 1) }
-    let(:package) { double(Spree::Stock::Package,
-          order: mock_model(Spree::Order, :ship_address => address),
-          contents: [Spree::Stock::Package::ContentItem.new(nil, variant1, 10),
-                    Spree::Stock::Package::ContentItem.new(nil, variant2, 4),
-                    Spree::Stock::Package::ContentItem.new(nil, variant3, 1)]) }
+    let(:stock_location) { FactoryGirl.create(:stock_location, address1: '1313 S Harbor Blvd', address2: '', city: 'Anaheim', state: california, country: usa, phone: '7147814000', active: 1) }
+    let(:line_item1) { double(Spree::LineItem, variant: variant1) }
+    let(:line_item2) { double(Spree::LineItem, variant: variant2) }
+    let(:line_item3) { double(Spree::LineItem, variant: variant3) }
+    let(:line_item4) { double(Spree::LineItem, variant: variant4) }
+    let(:line_item5) { double(Spree::LineItem, variant: variant5) }
+    let(:line_item6) { double(Spree::LineItem, variant: variant6) }
+    let(:line_item7) { double(Spree::LineItem, variant: variant7) }
+    let(:line_item8) { double(Spree::LineItem, variant: variant8) }
+    let(:package) do
+      double(
+        Spree::Stock::Package,
+        order: mock_model(Spree::Order, ship_address: address),
+        contents: [
+          Spree::Stock::Package::ContentItem.new(line_item1, variant1, 10),
+          Spree::Stock::Package::ContentItem.new(line_item2, variant2, 4),
+          Spree::Stock::Package::ContentItem.new(line_item3, variant3, 1)
+        ],
+        stock_location: stock_location
+      )
+    end
 
     let(:too_heavy_package) do
       Spree::Stock::Package.extend ActiveModel::Naming
       mock_model(
         Spree::Stock::Package,
-        order: mock_model(Spree::Order, :ship_address => address),
+        order: mock_model(Spree::Order, ship_address: address),
         stock_location: stock_location,
         contents: [
-          Spree::Stock::Package::ContentItem.new(nil, variant3, 2),
-          Spree::Stock::Package::ContentItem.new(nil, variant4, 2)
+          Spree::Stock::Package::ContentItem.new(line_item3, variant3, 2),
+          Spree::Stock::Package::ContentItem.new(line_item4, variant4, 2)
         ]
       )
     end
 
-    let(:us_package) { double(Spree::Stock::Package,
-          order: mock_model(Spree::Order, :ship_address => us_address),
-          contents: [Spree::Stock::Package::ContentItem.new(nil, variant1, 10),
-                    Spree::Stock::Package::ContentItem.new(nil, variant2, 4),
-                    Spree::Stock::Package::ContentItem.new(nil, variant3, 1)]) }
+    let(:us_package) do
+      double(Spree::Stock::Package,
+          stock_location: stock_location,
+          order: mock_model(Spree::Order, ship_address: us_address),
+          contents: [Spree::Stock::Package::ContentItem.new(line_item1, variant1, 10),
+                    Spree::Stock::Package::ContentItem.new(line_item2, variant2, 4),
+                    Spree::Stock::Package::ContentItem.new(line_item3, variant3, 1)])
+    end
+
     let(:package_with_invalid_weights) { double(Spree::Stock::Package,
-          order: mock_model(Spree::Order, :ship_address => us_address),
-          contents: [Spree::Stock::Package::ContentItem.new(nil, variant5, 1),
-                    Spree::Stock::Package::ContentItem.new(nil, variant6, 1)]) }
-    let(:package_with_packages) { double(Spree::Stock::Package,
-          order: mock_model(Spree::Order, :ship_address => us_address),
-          contents: [Spree::Stock::Package::ContentItem.new(nil, variant8, 4),
-                    Spree::Stock::Package::ContentItem.new(nil, variant7, 2)]) }
-    let(:international_calculator) {  Spree::Calculator::Shipping::Usps::PriorityMailInternational.new }
-    let(:domestic_calculator) {  Spree::Calculator::Shipping::Usps::PriorityMail.new }
+          stock_location: stock_location,
+          order: mock_model(Spree::Order, ship_address: us_address),
+          contents: [Spree::Stock::Package::ContentItem.new(line_item5, variant5, 1),
+                    Spree::Stock::Package::ContentItem.new(line_item6, variant6, 1)]) }
+
+    let(:package_with_packages) do
+      double(
+        Spree::Stock::Package,
+        order: mock_model(Spree::Order, ship_address: us_address),
+        contents: [
+          Spree::Stock::Package::ContentItem.new(line_item7, variant8, 4),
+          Spree::Stock::Package::ContentItem.new(line_item8, variant7, 2)
+        ],
+        stock_location: stock_location
+      )
+    end
+
+    let(:international_calculator) { Spree::Calculator::Shipping::Usps::PriorityMailInternational.new }
+    let(:domestic_calculator) { Spree::Calculator::Shipping::Usps::PriorityMail.new }
+    let(:multiplier) { Spree::ActiveShipping::Config[:unit_multiplier] }
 
     before(:each) do
       Rails.cache.clear
-      Spree::ActiveShipping::Config.set(:units => "imperial")
-      Spree::ActiveShipping::Config.set(:unit_multiplier => 16)
-      Spree::ActiveShipping::Config.set(:default_weight => 1)
+      Spree::ActiveShipping::Config.set(units: "imperial")
+      Spree::ActiveShipping::Config.set(unit_multiplier: 16)
+      Spree::ActiveShipping::Config.set(default_weight: 1)
     end
 
     describe "compute" do
       context "for international calculators" do
         it "should convert package contents to weights array for non-US countries (ex. Canada [limit = 66lbs])" do
           weights = international_calculator.send :convert_package_to_weights_array, package
-          weights.should == [20.0, 21.0, 29.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
+          expect(weights).to eq [54.25, 65.25, 65.25, 65.25].map{ |x| x * multiplier }
         end
 
         it "should create array of packages" do
           packages = international_calculator.send :packages, package
-          packages.size.should == 5
-          packages.map{|package| package.weight.amount}.should == [41.0, 29.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-          packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+          expect(packages.size).to eq(4)
+          expect(packages.map{ |package| package.weight.amount }).to eq [54.25, 65.25, 65.25, 65.25].map{ |x| x * multiplier }
+          expect(packages.map{ |package| package.weight.unit }.uniq).to eq [:ounces]
         end
 
         context "raise exception if max weight exceeded" do
           it "should get Spree::ShippingError" do
-            too_heavy_package.stub(:weight) do
+            allow(too_heavy_package).to receive(:weight) do
               too_heavy_package.contents.sum{ |item| item.variant.weight * item.quantity }
             end
             expect { international_calculator.compute(too_heavy_package) }.to raise_error(Spree::ShippingError)
@@ -90,58 +120,58 @@ module ActiveShipping
       context "for domestic calculators" do
         it "should not convert order line items to weights array for US" do
           weights = domestic_calculator.send :convert_package_to_weights_array, us_package
-          weights.should == [20.0, 21.0, 29.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
+          expect(weights).to eq [54.25, 65.25, 65.25, 65.25].map{ |x| x * multiplier }
         end
 
         it "should create array with one package for US" do
           packages = domestic_calculator.send :packages, us_package
-          packages.size.should == 4
-          packages.map{|package| package.weight.amount}.should == [70.0, 60.0, 60.0, 60.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-          packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+          expect(packages.size).to eq(4)
+          expect(packages.map{ |package| package.weight.amount }).to eq [54.25, 65.25, 65.25, 65.25].map{ |x| x * multiplier }
+          expect(packages.map{ |package| package.weight.unit }.uniq).to eq [:ounces]
         end
       end
     end
 
     describe "weight limits" do
       it "should be set for USPS calculators" do
-        international_calculator.send(:max_weight_for_country, country).should == 66.0 * Spree::ActiveShipping::Config[:unit_multiplier] # Canada
-        domestic_calculator.send(:max_weight_for_country, country).should == 70.0 * Spree::ActiveShipping::Config[:unit_multiplier]
+        expect(international_calculator.send(:max_weight_for_country, country)).to eq(66.0 * multiplier) # Canada
+        expect(domestic_calculator.send(:max_weight_for_country, country)).to eq(70.0 * multiplier)
       end
 
       it "should respect the max weight per package" do
-        Spree::ActiveShipping::Config.set(:max_weight_per_package => 30)
+        Spree::ActiveShipping::Config.set(max_weight_per_package: 30)
         weights = international_calculator.send :convert_package_to_weights_array, package
-        weights.should == [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 21.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
+        expect(weights).to eq [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 25.25, 25.25, 25.25, 25.25, 29].map{ |x| x * multiplier }
 
         packages = international_calculator.send :packages, package
-        packages.size.should == 12
-        packages.map{|package| package.weight.amount}.should == [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 21.0, 29.0].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-        packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+        expect(packages.size).to eq(11)
+        expect(packages.map{ |package| package.weight.amount }).to eq [20.0, 20.0, 20.0, 20.0, 20.0, 20.0, 25.25, 25.25, 25.25, 25.25, 29].map{ |x| x * multiplier }
+        expect(packages.map{ |package| package.weight.unit }.uniq). to eq [:ounces]
       end
     end
 
     describe "validation of line item weight" do
       it "should avoid zero weight or negative weight" do
         weights = domestic_calculator.send :convert_package_to_weights_array, package_with_invalid_weights
-        default_weight = Spree::ActiveShipping::Config[:default_weight] * Spree::ActiveShipping::Config[:unit_multiplier]
-        weights.should == [default_weight, default_weight]
+        default_weight = Spree::ActiveShipping::Config[:default_weight] * multiplier
+        expect(weights).to eq [default_weight * 2]
       end
     end
 
     describe "validation of default weight of zero" do
       it "should accept zero default weight" do
-        Spree::ActiveShipping::Config.set(:default_weight => 0)
+        Spree::ActiveShipping::Config.set(default_weight: 0)
         weights = domestic_calculator.send :convert_package_to_weights_array, package_with_invalid_weights
-        weights.should == [0, 0]
+        expect(weights).to eq [0]
       end
     end
 
     describe "adds item packages" do
-      it "should add item packages to weight calculation" do
+      xit "should add item packages to weight calculation" do
         packages = domestic_calculator.send :packages, package_with_packages
-        packages.size.should == 6
-        packages.map{|package| package.weight.amount}.should == [21, 58, 36, 36, 43, 43].map{|x| x * Spree::ActiveShipping::Config[:unit_multiplier]}
-        packages.map{|package| package.weight.unit}.uniq.should == [:ounces]
+        expect(packages.size).to eq(2)
+        expect(packages.map{ |package| package.weight.amount }).to eq [21, 58, 36, 36, 43, 43].map{ |x| x * multiplier }
+        expect(packages.map{ |package| package.weight.unit }.uniq).to eq([:ounces])
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -69,7 +69,7 @@ RSpec.configure do |config|
   config.use_transactional_fixtures = true
 
   #config.include Spree::UrlHelpers
-  #config.include Devise::TestHelpers, :type => :controller
+  #config.include Devise::TestHelpers, type: :controller
 
 end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -38,6 +38,14 @@ require 'spree/testing_support/url_helpers'
 Dir[File.join(File.dirname(__FILE__), "factories/*.rb")].each {|f| require f }
 
 RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+     c.syntax = :expect
+   end
+
+  config.infer_spec_type_from_file_location!
+  config.filter_run_including focus: true
+  config.run_all_when_everything_filtered = true
+
   config.include Spree::TestingSupport::ControllerRequests
   config.include FactoryGirl::Syntax::Methods
   config.include Spree::TestingSupport::UrlHelpers

--- a/spree_active_shipping.gemspec
+++ b/spree_active_shipping.gemspec
@@ -19,8 +19,9 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'spree_core', '~> 2.2.5'
   s.add_dependency 'active_shipping', '~> 0.12.4'
+  s.add_dependency 'box_packer', '~> 1.0'
   s.add_development_dependency 'ffaker'
-  s.add_development_dependency 'rspec-rails', '~> 2.13'
+  s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'pry'
   s.add_development_dependency 'webmock'
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
The current weight packing method is sub optimal in that it only attempts to fill a "package" by line item. It will not combine smaller line_items into a "package" that could be utilized. The bug that a customer reported was that if they had 5 of the same items in their cart, removed one and replaced it with the same item but of a different color, the shipping calculation cost increased when they did not expect it to.

Also: updated to rspec 3, updated spec syntax, and various formatting and spacing changes.