### PR TITLE
NEMO-10586 - Update UPS calculators to always use the English description as the rate_result_key

### DIFF
--- a/app/models/spree/calculator/shipping/ups/base.rb
+++ b/app/models/spree/calculator/shipping/ups/base.rb
@@ -4,6 +4,18 @@ module Spree
   module Calculator::Shipping
     module Ups
       class Base < Spree::Calculator::Shipping::ActiveShipping::Base
+        class << self
+          def description(locale: I18n.locale)
+            I18n.t(translation_key, scope: :ups, locale: locale)
+          end
+
+          protected
+
+          def translation_key
+            self.name.demodulize.underscore.to_sym
+          end
+        end
+
         def carrier
           ActiveMerchant::Shipping::UPS.new(carrier_details)
         end
@@ -12,6 +24,10 @@ module Spree
         # weight limit in ounces http://www.ups.com/content/us/en/resources/prepare/oversize.html
         def max_weight_for_country(country)
           2400    # 150 lbs
+        end
+
+        def rate_result_key
+          self.class.description(locale: :en)
         end
 
         private

--- a/app/models/spree/calculator/shipping/ups/ground.rb
+++ b/app/models/spree/calculator/shipping/ups/ground.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '03'
         end
-
-        def self.description
-          I18n.t("ups.ground")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/next_day_air.rb
+++ b/app/models/spree/calculator/shipping/ups/next_day_air.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '01'
         end
-
-        def self.description
-          I18n.t("ups.next_day_air")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/next_day_air_early_am.rb
+++ b/app/models/spree/calculator/shipping/ups/next_day_air_early_am.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '14'
         end
-
-        def self.description
-          I18n.t("ups.next_day_air_early_am")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/next_day_air_saver.rb
+++ b/app/models/spree/calculator/shipping/ups/next_day_air_saver.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '13'
         end
-
-        def self.description
-          I18n.t("ups.next_day_air_saver")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/saver.rb
+++ b/app/models/spree/calculator/shipping/ups/saver.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '65'
         end
-
-        def self.description
-          I18n.t("ups.saver")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/second_day_air.rb
+++ b/app/models/spree/calculator/shipping/ups/second_day_air.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '02'
         end
-
-        def self.description
-          I18n.t("ups.second_day_air")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/second_day_air_am.rb
+++ b/app/models/spree/calculator/shipping/ups/second_day_air_am.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '59'
         end
-
-        def self.description
-          I18n.t("ups.second_day_air_am")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/standard.rb
+++ b/app/models/spree/calculator/shipping/ups/standard.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '11'
         end
-
-        def self.description
-          I18n.t("ups.standard")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/three_day_select.rb
+++ b/app/models/spree/calculator/shipping/ups/three_day_select.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '12'
         end
-
-        def self.description
-          I18n.t("ups.three_day_select")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/worldwide_expedited.rb
+++ b/app/models/spree/calculator/shipping/ups/worldwide_expedited.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '08'
         end
-
-        def self.description
-          I18n.t("ups.worldwide_expedited")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/worldwide_express.rb
+++ b/app/models/spree/calculator/shipping/ups/worldwide_express.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '07'
         end
-
-        def self.description
-          I18n.t("ups.worldwide_express")
-        end
       end
     end
   end

--- a/app/models/spree/calculator/shipping/ups/worldwide_express_plus.rb
+++ b/app/models/spree/calculator/shipping/ups/worldwide_express_plus.rb
@@ -9,10 +9,6 @@ module Spree
         def self.service_code
           '54'
         end
-
-        def self.description
-          I18n.t("ups.worldwide_express_plus")
-        end
       end
     end
   end

--- a/spec/models/spree/calculator/shipping/ups/standard_spec.rb
+++ b/spec/models/spree/calculator/shipping/ups/standard_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Spree::Calculator::Shipping::Ups::Standard do
+  subject { Spree::Calculator::Shipping::Ups::Standard }
+
+  let(:application_locale) { :en }
+
+  before { I18n.locale = application_locale }
+
+  describe '.description' do
+    context 'when :locale is not send' do
+      let(:expected) { I18n.t('ups.standard', locale: application_locale) }
+
+      it 'should return the description translated using the application locale' do
+        expect(subject.description).to eq(expected)
+      end
+    end
+
+    context 'when :locale is send' do
+      let(:locale) { :es }
+      let(:expected) { I18n.t('ups.standard', locale: locale) }
+
+      it 'should return the description translated using the locale param' do
+        expect(subject.description(locale: locale)).to eq(expected)
+      end
+    end
+  end
+
+  describe '#rate_result_key' do
+    subject { Spree::Calculator::Shipping::Ups::Standard.new }
+
+    let(:expected) { I18n.t('ups.standard', locale: :en) }
+
+    context 'when application locale is :en' do
+      it 'should return the description in english' do
+        expect(subject.send(:rate_result_key)).to eq(expected)
+      end
+    end
+
+    context 'when application locale is :es' do
+      it 'should return the description in english' do
+        expect(subject.send(:rate_result_key)).to eq(expected)
+      end
+    end
+  end
+end

--- a/spec/models/spree/calculator/shipping/ups/worldwide_express_spec.rb
+++ b/spec/models/spree/calculator/shipping/ups/worldwide_express_spec.rb
@@ -1,0 +1,44 @@
+RSpec.describe Spree::Calculator::Shipping::Ups::WorldwideExpress do
+  subject { Spree::Calculator::Shipping::Ups::WorldwideExpress }
+
+  let(:application_locale) { :en }
+
+  before { I18n.locale = application_locale }
+
+  describe '.description' do
+    context 'when :locale is not send' do
+      let(:expected) { I18n.t('ups.worldwide_express', locale: application_locale) }
+
+      it 'should return the description translated using the application locale' do
+        expect(subject.description).to eq(expected)
+      end
+    end
+
+    context 'when :locale is send' do
+      let(:locale) { :es }
+      let(:expected) { I18n.t('ups.worldwide_express', locale: locale) }
+
+      it 'should return the description translated using the locale param' do
+        expect(subject.description(locale: locale)).to eq(expected)
+      end
+    end
+  end
+
+  describe '#rate_result_key' do
+    subject { Spree::Calculator::Shipping::Ups::WorldwideExpress.new }
+
+    let(:expected) { I18n.t('ups.worldwide_express', locale: :en) }
+
+    context 'when application locale is :en' do
+      it 'should return the description in english' do
+        expect(subject.send(:rate_result_key)).to eq(expected)
+      end
+    end
+
+    context 'when application locale is :es' do
+      it 'should return the description in english' do
+        expect(subject.send(:rate_result_key)).to eq(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
The UPS `rates_result` is always returned in English, when the application uses a locale other than `:en` (eg: `:es`), the package is not computed. This PR fix this issue.

https://jira.godaddy.com/browse/NEMO-10586